### PR TITLE
Refactor: Remove deprecated setup_generative_ai function

### DIFF
--- a/.github/scripts/ai_utils.py
+++ b/.github/scripts/ai_utils.py
@@ -135,25 +135,6 @@ def get_provider() -> ModelProvider:
         return GLMProvider()
 
 
-def setup_generative_ai():
-    """
-    Legacy function for backward compatibility.
-    Returns the Gemini client directly.
-    
-    DEPRECATED: Use get_provider() instead.
-    """
-    from google import genai
-    
-    api_key = os.environ.get('GEMINI_API_KEY')
-    if not api_key:
-        logger.error("Critical Error: GEMINI_API_KEY not found!")
-        sys.exit(1)
-    
-    client = genai.Client(api_key=api_key)
-    logger.info("Gemini AI client configured successfully (legacy mode).")
-    return client
-
-
 def with_retry(func, max_retries: int = 3, base_delay: float = 1.0):
     """
     Execute a function with exponential backoff retry logic.


### PR DESCRIPTION
Removed deprecated `setup_generative_ai` function from `.github/scripts/ai_utils.py`. The function was unused and marked as legacy. All AI client instantiation is now handled via `get_provider()`.

Verification:
- Verified that `setup_generative_ai` is not used in the codebase.
- Ran `.github/scripts/test_smoke.py` successfully.
- Checked `.github/scripts/ai_utils.py` for correct removal.

---
*PR created automatically by Jules for task [1849657499302741859](https://jules.google.com/task/1849657499302741859) started by @buzaslan129*