### PR TITLE
🔒 Pin Jules Action to Commit SHA to prevent supply chain attacks

### DIFF
--- a/.github/workflows/agent-coder.yml
+++ b/.github/workflows/agent-coder.yml
@@ -204,7 +204,7 @@ jobs:
           fi
 
       - name: Invoke Coder (Async)
-        uses: google-labs-code/jules-action@v1.0.0
+        uses: google-labs-code/jules-action@bff7875eaa123cac6742b7cfc51005b95ba4d566 # v1.0.0
         with:
           jules_api_key: ${{ secrets.JULES_API_KEY }}
           starting_branch: ${{ github.event.inputs.base_branch || 'main' }}


### PR DESCRIPTION
* 🎯 **What:** Replaced the mutable tag `v1.0.0` for `google-labs-code/jules-action` with its specific commit SHA `bff7875eaa123cac6742b7cfc51005b95ba4d566`.
* ⚠️ **Risk:** Using mutable tags (like `v1.0.0`) in GitHub Actions allows the action code to change without warning. If the tag is moved to a malicious commit (e.g., via compromised maintainer credentials), it could execute arbitrary code in the workflow, leading to a supply chain attack.
* 🛡️ **Solution:** Pinned the action to an immutable commit hash (SHA). This ensures that the workflow always runs the exact same code, regardless of changes to the tag, eliminating the risk of unexpected updates or malicious tag hijacks.

---
*PR created automatically by Jules for task [17385818687753837566](https://jules.google.com/task/17385818687753837566) started by @buzaslan129*