### PR TITLE
Refactor: Centralize load_rules in ai_utils.py

### DIFF
--- a/.github/scripts/ai_utils.py
+++ b/.github/scripts/ai_utils.py
@@ -316,3 +316,21 @@ def load_prompt_template(prompt_path: Path) -> str:
     except IOError as e:
         logger.error(f"Error reading prompt file: {prompt_path} - {e}")
         raise
+
+def load_rules(filepath: str = '.github/swarm_rules.md') -> str:
+    """
+    Reads project rules from the configuration file.
+
+    Args:
+        filepath (str): Path to the rules file.
+
+    Returns:
+        str: Content of the file or a default message if not found.
+    """
+    try:
+        content = Path(filepath).read_text(encoding="utf-8")
+        logger.info(f"Loaded project rules from {filepath}")
+        return content
+    except FileNotFoundError:
+        logger.warning(f"No project rules found at {filepath}, using defaults")
+        return "No project rules found. Apply general Clean Code principles."

--- a/.github/scripts/swarm_analyzer.py
+++ b/.github/scripts/swarm_analyzer.py
@@ -21,7 +21,8 @@ from ai_utils import (
     parse_json_response,
     with_retry,
     redact_sensitive_data,
-    logger
+    logger,
+    load_rules
 )
 
 # Configuration Constants
@@ -84,16 +85,6 @@ def get_codebase_context(
     logger.info(f"Collected context from {total_files} files")
     return "\n".join(context_parts)
 
-
-def load_rules(filepath: str = '.github/swarm_rules.md') -> str:
-    """Reads project rules from the configuration file."""
-    try:
-        content = Path(filepath).read_text(encoding="utf-8")
-        logger.info("Loaded project rules")
-        return content
-    except FileNotFoundError:
-        logger.warning("No project rules found, using defaults")
-        return "No project rules found. Apply general Clean Code principles."
 
 
 def is_research_request(issue_data: Dict[str, Any]) -> bool:

--- a/.github/scripts/swarm_reviewer.py
+++ b/.github/scripts/swarm_reviewer.py
@@ -25,7 +25,8 @@ from ai_utils import (
     parse_json_response,
     with_retry,
     redact_sensitive_data,
-    logger
+    logger,
+    load_rules
 )
 
 
@@ -47,12 +48,6 @@ def get_diff_content(filepath: str = 'coder_changes.diff') -> str:
         return "No changes found"
 
 
-def load_rules(filepath: str = '.github/swarm_rules.md') -> str:
-    """Reads project rules from the file."""
-    try:
-        return Path(filepath).read_text(encoding="utf-8")
-    except FileNotFoundError:
-        return "No specific project rules found. Apply general Clean Code principles."
 
 
 def build_prompt(template: str, diff: str, rules: str) -> str:

--- a/.github/scripts/test_smoke.py
+++ b/.github/scripts/test_smoke.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Smoke tests for HiveMind AI Utils"""
 import sys
+import os
 sys.path.insert(0, '.')
 
-from ai_utils import parse_json_response, with_retry, redact_sensitive_data
+from ai_utils import parse_json_response, with_retry, redact_sensitive_data, load_rules
 
 def test_json_parsing():
     print("=== JSON PARSING TESTS ===")
@@ -101,12 +102,37 @@ def test_approval_logic():
     
     print("All approval tests PASSED!\n")
 
+def test_load_rules():
+    print("=== LOAD RULES TESTS ===")
+
+    # Test 1: File exists
+    dummy_file = "dummy_rules.md"
+    dummy_content = "Rule 1: Be cool."
+    with open(dummy_file, "w") as f:
+        f.write(dummy_content)
+
+    try:
+        content = load_rules(dummy_file)
+        assert content == dummy_content
+        print("Test 1 PASSED: File loaded successfully")
+    finally:
+        if os.path.exists(dummy_file):
+            os.remove(dummy_file)
+
+    # Test 2: File missing
+    content = load_rules("non_existent_rules.md")
+    assert "No project rules found" in content
+    print("Test 2 PASSED: Missing file handled gracefully")
+
+    print("All load_rules tests PASSED!\n")
+
 if __name__ == "__main__":
     try:
         test_json_parsing()
         test_retry_logic()
         test_redaction()
         test_approval_logic()
+        test_load_rules()
         print("=" * 40)
         print("ALL SMOKE TESTS PASSED!")
         print("=" * 40)


### PR DESCRIPTION
Moved the `load_rules` function from `swarm_reviewer.py` and `swarm_analyzer.py` to `ai_utils.py` to reduce code duplication and improve maintainability. Added unit tests for `load_rules` in `test_smoke.py`. Verified changes with existing and new tests.

---
*PR created automatically by Jules for task [2291109370056007146](https://jules.google.com/task/2291109370056007146) started by @buzaslan129*