### PR TITLE
refactor: Centralize file reading limits with constants

### DIFF
--- a/.github/scripts/ai_utils.py
+++ b/.github/scripts/ai_utils.py
@@ -23,6 +23,10 @@ except ImportError:
     TypeAdapter = None
     ValidationError = None
 
+# Constants
+MAX_DIFF_READ_LIMIT = 30000
+MAX_RULES_READ_LIMIT = 50000
+
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,
@@ -389,7 +393,13 @@ def load_rules(filepath: str = '.github/swarm_rules.md') -> str:
         str: Content of the file or a default message if not found.
     """
     try:
-        content = Path(filepath).read_text(encoding="utf-8")
+        with open(filepath, 'r', encoding="utf-8") as f:
+            content = f.read(MAX_RULES_READ_LIMIT + 1)
+
+        if len(content) > MAX_RULES_READ_LIMIT:
+            logger.warning(f"Rules file {filepath} truncated because it exceeds {MAX_RULES_READ_LIMIT} chars")
+            content = content[:MAX_RULES_READ_LIMIT] + "\n\n... [RULES TRUNCATED] ..."
+
         logger.info(f"Loaded project rules from {filepath}")
         return content
     except FileNotFoundError:

--- a/.github/scripts/swarm_analyzer.py
+++ b/.github/scripts/swarm_analyzer.py
@@ -23,7 +23,8 @@ from ai_utils import (
     with_retry,
     redact_sensitive_data,
     logger,
-    load_rules
+    load_rules,
+    MAX_RULES_READ_LIMIT
 )
 
 class AnalysisResult(BaseModel):
@@ -51,7 +52,7 @@ RESEARCH_KEYWORDS = [
 def get_codebase_context(
     root_dir: Path,
     max_files: int = 20,
-    max_len: int = 2000,
+    max_len: int = MAX_RULES_READ_LIMIT,
     extensions: set = None,
     priority_dirs: list = None
 ) -> str:
@@ -91,7 +92,12 @@ def get_codebase_context(
                 if file_path.is_file() and file_path.name.endswith(valid_extensions):
                     try:
                         with file_path.open(encoding='utf-8') as f:
-                            content = f.read(max_len)
+                            content = f.read(max_len + 1)
+
+                        if len(content) > max_len:
+                            logger.warning(f"File {file_path} truncated to {max_len} chars")
+                            content = content[:max_len] + "\n... [TRUNCATED]"
+
                         relative_path = file_path.relative_to(root_dir)
                         # Use suffix as language identifier (removing dot)
                         lang = file_path.suffix[1:] if file_path.suffix else "txt"

--- a/.github/scripts/swarm_reviewer.py
+++ b/.github/scripts/swarm_reviewer.py
@@ -27,7 +27,8 @@ from ai_utils import (
     with_retry,
     redact_sensitive_data,
     logger,
-    load_rules
+    load_rules,
+    MAX_DIFF_READ_LIMIT
 )
 
 class ReviewResult(BaseModel):
@@ -47,13 +48,12 @@ def get_diff_content(filepath: str = 'coder_changes.diff') -> str:
     Reads the diff content from the specified file path.
     Truncates large diffs and adds notice.
     """
-    limit = 30000
     try:
         with open(filepath, 'r', encoding="utf-8") as f:
-            content = f.read(limit + 1)
-            if len(content) > limit:
-                logger.warning(f"Diff truncated because it exceeds {limit} chars")
-                return content[:limit] + "\n\n... [DIFF TRUNCATED DUE TO SIZE LIMIT] ..."
+            content = f.read(MAX_DIFF_READ_LIMIT + 1)
+            if len(content) > MAX_DIFF_READ_LIMIT:
+                logger.warning(f"Diff truncated because it exceeds {MAX_DIFF_READ_LIMIT} chars")
+                return content[:MAX_DIFF_READ_LIMIT] + "\n\n... [DIFF TRUNCATED DUE TO SIZE LIMIT] ..."
             return content
     except FileNotFoundError:
         logger.warning(f"Diff file not found: {filepath}")

--- a/.github/scripts/test_analyzer.py
+++ b/.github/scripts/test_analyzer.py
@@ -78,5 +78,27 @@ class TestSwarmAnalyzer(unittest.TestCase):
 
         self.assertIn("src/deep/nested/file.py", context)
 
+    def test_context_truncation(self):
+        limit = 100
+        content = "a" * (limit + 50)
+        self.create_file("src/large_file.py", content)
+
+        with self.assertLogs(level='WARNING') as cm:
+            context = get_codebase_context(
+                self.test_dir,
+                max_files=10,
+                max_len=limit,
+                priority_dirs=['src'],
+                extensions={'.py'}
+            )
+
+        # Check truncation
+        self.assertIn("src/large_file.py", context)
+        expected_content = "a" * limit + "\n... [TRUNCATED]"
+        self.assertIn(expected_content, context)
+
+        # Check warning
+        self.assertTrue(any("truncated" in log for log in cm.output))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Changes
- Defined `MAX_DIFF_READ_LIMIT` (30000) and `MAX_RULES_READ_LIMIT` (50000) in `.github/scripts/ai_utils.py`.
- Updated `load_rules` in `ai_utils.py` to enforce `MAX_RULES_READ_LIMIT` with truncation warning.
- Updated `get_diff_content` in `.github/scripts/swarm_reviewer.py` to use `MAX_DIFF_READ_LIMIT`.
- Updated `get_codebase_context` in `.github/scripts/swarm_analyzer.py` to use `MAX_RULES_READ_LIMIT` and added truncation logic.
- Added `test_context_truncation` to `.github/scripts/test_analyzer.py` to verify truncation and logging.
- Verified that `.github/scripts/add_comment.py`, `.github/scripts/patch_swarm_analyzer.py`, and `.github/scripts/benchmark_read.py` were already deleted.

Fixes #75
<!-- SWARM_COMMENT_ID: 3865061068 -->

---
*PR created automatically by Jules for task [13277538764575015898](https://jules.google.com/task/13277538764575015898) started by @buzaslan129*