### PR TITLE
docs: refresh public docs + prepare v2.2.0 release flow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,33 @@
+name: Bug Report
+description: Report a reproducible issue
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What happened?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version / Tag
+      placeholder: e.g. v2.1.1

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,24 @@
+name: Feature Request
+description: Propose an improvement
+title: "[Feature]: "
+labels: ["enhancement", "triage"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem are you solving?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed Solution
+      description: What should be implemented?
+    validations:
+      required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: Risk, scope, or migration notes

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+
+- What changed?
+- Why was it needed?
+
+## Validation
+
+- [ ] README links and matrices updated
+- [ ] Workflow references checked against `.github/workflows/*.yml`
+- [ ] Security/contribution docs reviewed
+
+## Release Prep Impact
+
+- [ ] CHANGELOG updated (if needed)
+- [ ] Release checklist considered (if relevant)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+This format is inspired by Keep a Changelog and uses Semantic Versioning.
+
+## [Unreleased] (v2.2.0 Prep)
+
+### Added
+- README refresh for quick onboarding, configuration matrix, trigger matrix, and release policy.
+- Troubleshooting and FAQ expansion for common setup/runtime issues.
+- Pull request and issue templates for cleaner contributor intake.
+- Release checklist document for repeatable release execution.
+
+### Changed
+- CONTRIBUTING flow synchronized with current workflow model.
+- SECURITY policy updated with concrete reporting and response expectations.
+
+## [v2.1.1] - 2026-01-14
+
+### Fixed
+- Resolved CodeQL command injection vulnerability in reviewer workflow.
+
+## [v2.1.0] - 2026-01-14
+
+### Added
+- Enterprise security and dynamic logic improvements.
+
+## [v2.0.0] - 2026-01-14
+
+### Added
+- HiveMind Actions 2.0 enterprise stability baseline.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,48 +1,51 @@
-# 🤝 Contributing to HiveMind Actions
+# Contributing to HiveMind Actions
 
-We love your input! We want to make contributing to HiveMind as easy and transparent as possible, whether it's:
+Thanks for contributing.
 
-- Reporting a bug
-- Discussing the current state of the code
-- Submitting a fix
-- Proposing new features
-- Becoming a maintainer
+## Contribution Flow (PR to `main`)
 
-## 📞 Contact
-For security issues or urgent matters, please contact: **buzaslan.ea@gmail.com**
+1. Fork the repository.
+2. Clone your fork.
+3. Create a feature branch.
+4. Make focused changes.
+5. Push your branch.
+6. Open a Pull Request targeting `main`.
 
-## 👩‍💻 Development Process
+Example:
 
-1.  **Fork** the repo on GitHub.
-2.  **Clone** the project to your own machine.
-3.  **Create a Branch** for your changes.
-    ```bash
-    git checkout -b feature/amazing-feature
-    ```
-4.  **Commit** changes to your own branch.
-    ```bash
-    git commit -B "feat: Add amazing feature"
-    ```
-5.  **Push** your work back up to your fork.
-    ```bash
-    git push origin feature/amazing-feature
-    ```
-6.  **Submit a Pull Request** so that we can review your changes.
+```bash
+git checkout -b feature/amazing-feature
+git add .
+git commit -m "feat: add amazing feature"
+git push origin feature/amazing-feature
+```
 
-## 🤖 AI-Powered Review Process
+## Minimal Validation Before PR
 
-HiveMind itself protects this repository! 🤯
-When you open a PR:
-1.  **Analyst & Reviewer Agents** will automatically inspect your code.
-2.  They will check for **Security**, **Best Practices**, and **Golden Rules**.
-3.  If they request changes, please address them.
-4.  Once the AI is satisfied, the **Human Maintainer** (@BUZASLAN128) will do the final merge approval.
+- Confirm workflow docs match implementation files in `.github/workflows/`.
+- Validate links and section integrity in `README.md`.
+- Run Python tests after dependencies are installed:
 
-## 📝 Rules
+```bash
+python -m pip install -r .github/requirements.txt
+python -m pytest .github/scripts/test_ai_utils.py .github/scripts/test_analyzer.py -q
+```
 
-- **Follow the Golden Rules:** Check `.github/swarm_rules.md`.
-- **Clean Code:** Keep it simple, readable, and documented.
-- **Tests:** Adding new features? Add tests.
+## AI Review Process
 
-## 📄 License
-By contributing, you agree that your contributions will be licensed under its MIT License.
+- Analyst/Coder/Reviewer workflows are part of the repository quality gate.
+- Reviewer may request or trigger self-correction if quality criteria are not met.
+
+## Ground Rules
+
+- Follow `.github/swarm_rules.md`.
+- Keep changes small, clear, and documented.
+- Do not commit secrets or private credentials.
+
+## Contact
+
+For urgent security matters: **buzaslan.ea@gmail.com**
+
+## License
+
+By contributing, you agree that contributions are licensed under the MIT License.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 <p align="center">
   <a href="https://github.com/BUZASLAN128/HiveMind-Actions/actions"><b>View Actions</b></a> |
   <a href="https://github.com/BUZASLAN128/HiveMind-Actions/pull/89"><b>See Self-Correction PoC</b></a> |
-  <a href="https://github.com/BUZASLAN128/HiveMind-Actions/issues/91"><b>See Push Security PoC</b></a> |
+  <a href="https://github.com/BUZASLAN128/HiveMind-Actions/issues/76"><b>See Push Review PoC</b></a> |
   <a href="https://github.com/BUZASLAN128/HiveMind-Actions/releases"><b>Releases</b></a>
 </p>
 
@@ -49,9 +49,11 @@ HiveMind turns GitHub events into an autonomous delivery loop:
 
 ### Verified push-level critical detection
 
-- Issue #91: https://github.com/BUZASLAN128/HiveMind-Actions/issues/91
-- Issue #92: https://github.com/BUZASLAN128/HiveMind-Actions/issues/92
 - Issue #76: https://github.com/BUZASLAN128/HiveMind-Actions/issues/76
+- Issue #75: https://github.com/BUZASLAN128/HiveMind-Actions/issues/75
+- Issue #11: https://github.com/BUZASLAN128/HiveMind-Actions/issues/11
+
+Note: examples above are selected from reviewer findings with real code-review output (not balance/quota failures).
 
 ### Additional delivery examples
 

--- a/README.md
+++ b/README.md
@@ -10,14 +10,8 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/BUZASLAN128/HiveMind-Actions"><img src="https://img.shields.io/github/stars/BUZASLAN128/HiveMind-Actions?style=flat-square" alt="GitHub stars"/></a>
-  <a href="https://github.com/BUZASLAN128/HiveMind-Actions/releases"><img src="https://img.shields.io/github/v/tag/BUZASLAN128/HiveMind-Actions?style=flat-square" alt="Latest tag"/></a>
-  <a href="https://github.com/BUZASLAN128/HiveMind-Actions/pulls"><img src="https://img.shields.io/github/issues-pr/BUZASLAN128/HiveMind-Actions?style=flat-square" alt="Open PRs"/></a>
-</p>
-
-<p align="center">
   <a href="https://github.com/BUZASLAN128/HiveMind-Actions/actions"><b>View Actions</b></a> |
-  <a href="https://github.com/BUZASLAN128/HiveMind-Actions/pull/89"><b>See Self-Correction PoC</b></a> |
+  <a href="https://github.com/BUZASLAN128/HiveMind-Actions/pulls?q=is%3Apr+is%3Amerged"><b>See Merged PR Examples</b></a> |
   <a href="https://github.com/BUZASLAN128/HiveMind-Actions/issues/76"><b>See Push Review PoC</b></a> |
   <a href="https://github.com/BUZASLAN128/HiveMind-Actions/releases"><b>Releases</b></a>
 </p>
@@ -42,11 +36,6 @@ HiveMind turns GitHub events into an autonomous delivery loop:
 
 ## Live Proof from This Repository
 
-### Verified self-correction
-
-- PR #89 (merged): reviewer loop evidence (`Loop: 1/5`)  
-  https://github.com/BUZASLAN128/HiveMind-Actions/pull/89
-
 ### Verified push-level critical detection
 
 - Issue #76: https://github.com/BUZASLAN128/HiveMind-Actions/issues/76
@@ -55,7 +44,7 @@ HiveMind turns GitHub events into an autonomous delivery loop:
 
 Note: examples above are selected from reviewer findings with real code-review output (not balance/quota failures).
 
-### Additional delivery examples
+### Featured merged PR examples
 
 - PR #79 (supply-chain hardening): https://github.com/BUZASLAN128/HiveMind-Actions/pull/79
 - PR #88 (config + metrics): https://github.com/BUZASLAN128/HiveMind-Actions/pull/88

--- a/README.md
+++ b/README.md
@@ -1,204 +1,154 @@
-# 🧠 HiveMind Actions 2.0
+# HiveMind Actions
 
-> **The First "Serverless" Swarm AI for GitHub Actions.**  
-> Turn your repository into a self-healing, multi-agent AI workspace with zero infrastructure cost.
+Serverless multi-agent automation for GitHub Actions: Analyst plans, Coder implements, Reviewer verifies, and self-correction closes the loop.
 
-[![Live Issue #1](https://img.shields.io/badge/HiveMind-Live_Issue_%231-blue?style=for-the-badge&logo=github)](https://github.com/BUZASLAN128/HiveMind-Actions/issues/1)
-[![Live PR #32](https://img.shields.io/badge/HiveMind-Live_Issue_%231-blue?style=for-the-badge&logo=github)](https://github.com/BUZASLAN128/HiveMind-Actions/pull/32)
+## Quick Links
 
----
+- Repository: https://github.com/BUZASLAN128/HiveMind-Actions
+- Actions: https://github.com/BUZASLAN128/HiveMind-Actions/actions
+- Analyst Workflow: https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-analyst.yml
+- Coder Workflow: https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-coder.yml
+- Reviewer Workflow: https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-reviewer.yml
+- Releases: https://github.com/BUZASLAN128/HiveMind-Actions/releases
+- Latest Tag: https://github.com/BUZASLAN128/HiveMind-Actions/releases/tag/v2.1.1
 
-## 🌟 What is this?
+[![Analyst Workflow](https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-analyst.yml/badge.svg)](https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-analyst.yml)
+[![Coder Workflow](https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-coder.yml/badge.svg)](https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-coder.yml)
+[![Reviewer Workflow](https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-reviewer.yml/badge.svg)](https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-reviewer.yml)
 
-**HiveMind** is not just a bot. It's a **collaborative AI Swarm** that lives inside your GitHub Actions.
-It enables **Analyst**, **Coder**, and **Reviewer** agents to work together, autonomously planning, coding, reviewing, and **fixing their own mistakes** without your intervention.
+## What It Does
 
-Think of it as having a **Senior Developer** (Jules) and a **Staff Engineer** (Reviewer) working 24/7 on your repo, for free (using Gemini Free Tier).
+HiveMind Actions turns a repository into an autonomous collaboration flow:
 
----
+- Analyst converts issue intent into implementable plans.
+- Coder executes the plan and opens/updates PRs.
+- Reviewer checks code quality, security, and project rules.
+- Reviewer can trigger self-correction when PR quality is insufficient.
 
-## 🔥 Why HiveMind? (Killer Features)
+## 1-Minute Quickstart
 
-### 1. ♾️ Autonomous Self-Correction Loop
+1. Copy these paths into your repository:
+   - `.github/workflows/`
+   - `.github/scripts/`
+   - `.github/prompts/`
+   - `.github/swarm_rules.md`
+   - `.github/config.json`
+2. Add required secrets and variables in `Settings -> Secrets and variables -> Actions`.
+3. Create an issue and comment `@analyst`.
+4. Analyst runs, dispatches Coder (`workflow_dispatch`), Coder opens PR, Reviewer evaluates PR.
 
-The most powerful feature. If the **Reviewer** agent finds a bug or security flaw in a PR:
+## Configuration Matrix (Source of Truth)
 
-1. It **REJECTS** the PR.
-2. It talks directly to **Jules** (the Coder) via API.
-3. Jules **fixes the code** and pushes a new commit.
-4. The Reviewer **re-evaluates** the fix.
-5. This loop continues until the code is perfect. **You sleep, they work.**
+### Secrets and Variables
 
-### 2. 🧠 Smart Context & Golden Rules
+| Name | Required | Used By | Purpose |
+|---|---|---|---|
+| `GLM_API_KEY` | Yes (if provider=`glm`) | `agent-analyst.yml`, `agent-reviewer.yml` | GLM provider access |
+| `GEMINI_API_KEY` | Yes (if provider=`gemini`) | `agent-analyst.yml`, `agent-reviewer.yml` | Gemini provider access |
+| `JULES_API_KEY` | Yes | `agent-coder.yml`, `agent-reviewer.yml` | Coder execution + reviewer self-correction calls |
+| `APP_ID` | Optional | `agent-reviewer.yml` | GitHub App auth for branded bot identity |
+| `APP_PRIVATE_KEY` | Optional | `agent-reviewer.yml` | Pair for `APP_ID` |
+| `SWARM_MODEL_PROVIDER` | Optional (`glm` default) | `agent-analyst.yml`, `agent-reviewer.yml` | Select active model provider |
 
-HiveMind doesn't just "guess". It follows your **Golden Rules** defined in `.github/swarm_rules.md`.
+### Workflow Permission Expectations
 
-- Have a specific architectural style? Write it down.
-- Want to ban `any` type in TypeScript? Add a rule.
-- The Swarm **strictly enforces** your standards.
+| Workflow | Key Permissions |
+|---|---|
+| `agent-analyst.yml` | `actions: write`, issue/comment read-write |
+| `agent-coder.yml` | contents and PR write scopes for automation |
+| `agent-reviewer.yml` | pull request review/comment write scopes |
 
-### 3. 🛡️ Beast Mode (Proactive Security)
+## Trigger Matrix
 
-HiveMind acts as an **always-on security guard**.
+| Workflow | Trigger | Notes |
+|---|---|---|
+| `agent-analyst.yml` | `issue_comment` (`@analyst` or `@analyze`) | Entry point for tasks |
+| `agent-coder.yml` | `workflow_dispatch` | Dispatched by Analyst; centralized execution |
+| `agent-reviewer.yml` | `pull_request` (`opened`, `synchronize`, `ready_for_review`) | Reviews and may trigger self-correction |
 
-- Pushed code to `any`? The Reviewer inspects it instantly.
-- Found a critical vulnerability? It autonomously **opens an Issue** and assigns it to the team.
-- No security hole goes unnoticed.
+## Version and Release Policy
 
-### 4. ⚡ Competitive Intelligence (Smart Actions)
+Current public tags:
 
-- **Smart Ignore:** Automatically skips junk files (`package-lock.json`, `dist/`, `*.min.js`) to save tokens and reduce noise.
-- **Auto-Labeler:** AI analyzes your PR and tags it automatically (`bug`, `feature`, `security`, `refactor`).
-- **Token Optimization:** Uses efficient diff parsing to handle large PRs without breaking the bank.
+- `v2.0.0`
+- `v2.1.0`
+- `v2.1.1`
 
-### 5. Zero-Config (Serverless)
+Preparation target: `v2.2.0`.
 
-No servers to manage. No Docker containers to host.
+SemVer policy:
 
-- Runs entirely on **GitHub Actions runners**.
-- Uses **Google Gemini 2.0 Flash** or **GLM-4.7** (configurable).
-- Just copy the workflow files and you're done.
+- `MAJOR`: breaking workflow/protocol changes.
+- `MINOR`: new capabilities without breaking current setup.
+- `PATCH`: bugfixes and reliability improvements.
 
-### 6. Multi-Model AI Support
+Tag vs Release:
 
-HiveMind supports multiple AI providers out of the box:
+- **Tag** marks source state (`git tag`).
+- **GitHub Release** is distribution metadata (notes, changelog mapping, assets if added).
 
-| Provider | Models | Best For | Cost |
-|----------|--------|----------|------|
-| **GLM-4.7** (z.ai) | glm-4.7, glm-4.6, glm-4.5, glm-4.5-Air | Coding tasks, Turkish support | Coding Plan (free tier available) |
-| **Gemini** (Google) | gemini-2.0-flash, gemini-1.5-pro | General analysis, fast responses | Free tier available |
+For `v2.2.0`, prepare changelog + release notes first, then create a proper GitHub Release from the tag.
 
-**Configuration:**
+## Download and Release Channel
 
-```bash
-# In GitHub Secrets:
-GLM_API_KEY=your-z.ai-api-key
-GEMINI_API_KEY=your-google-api-key
+- Releases page: https://github.com/BUZASLAN128/HiveMind-Actions/releases
+- Changelog source: `CHANGELOG.md`
+- Release checklist: `RELEASE_CHECKLIST.md`
 
-# In GitHub Variables:
-SWARM_MODEL_PROVIDER=glm  # or 'gemini'
-```
+Recommended release content:
 
----
+- Summary of workflow-level changes
+- Breaking/non-breaking classification
+- Security or behavior-impact notes
+- Upgrade guidance from previous tag
 
-## 🤖 The Swarm Agents
+## Troubleshooting
 
-| Agent | Icon | Role | Superpower |
-|-------|------|------|------------|
-| **Analyst** | 🔍 | Architect | Breaks down complex issues into step-by-step plans. |
-| **Coder (Jules)** | 🐝 | Droneworker | Writes code, fixes bugs, and handles git operations autonomously. |
-| **Reviewer** | 🔎 | Quality Gate | Enforces rules, checks security, and **blocks bad PRs**. |
+### Missing API key errors
 
-### 🔄 The HiveMind Workflow: How Agents are Triggered
+- Verify `GLM_API_KEY` or `GEMINI_API_KEY` based on `SWARM_MODEL_PROVIDER`.
+- Verify `JULES_API_KEY` exists for coder/reviewer handoff.
 
-The HiveMind Swarm operates in a sequential, predictable, and centralized manner to ensure stability and prevent redundant operations. Here’s how the agents collaborate:
+### Analyst does not trigger
 
-1. **🔍 Analyst Agent (`agent-analyst.yml`)**
-    - **Trigger:** A user with write-access posts a comment containing `@analyst` or `@analyze` on an issue.
-    - **Action:** The Analyst assesses the issue, gathers context from the codebase, and creates a detailed implementation plan.
-    - **Output:** It triggers the Coder Agent by dispatching a `workflow_dispatch` event.
+- Ensure comment is on an issue and includes `@analyst` or `@analyze`.
+- Ensure commenter has required repository permissions.
 
-2. **🤖 Coder Agent (`agent-coder.yml`)**
-    - **Trigger:** Receives a `workflow_dispatch` event exclusively from the Analyst Agent.
-        - **Note:** Manual triggers (via issue comments or labels) have been **removed** to centralize control and prevent the agent from running multiple times on the same task.
-    - **Action:** The Coder (Jules) executes the plan from the Analyst, writes code, runs tests, and opens a pull request.
-    - **Output:** A pull request ready for review.
+### Coder not running after Analyst
 
-3. **🔎 Reviewer Agent (`agent-reviewer.yml`)**
-    - **Trigger:** A pull request is `opened`, `synchronize`d (a new commit is pushed), or marked `ready_for_review`.
-    - **Action:** The Reviewer inspects the code changes against the project's golden rules (`swarm_rules.md`), checks for security vulnerabilities, and analyzes for bugs.
-    - **Output:**
-        - **If Approved:** The pull request is approved and can be merged.
-        - **If Rejected:** The Reviewer initiates the **Self-Correction Loop**, sending feedback directly to the Coder Agent to fix the issues automatically.
+- Confirm `agent-analyst.yml` can dispatch workflow (`actions: write`).
+- Check Actions logs for `workflow_dispatch` payload and inputs.
 
-This centralized, dispatch-based flow ensures that each agent acts only when it's supposed to, creating a robust and reliable automation pipeline.
+### Reviewer self-correction not firing
 
-```mermaid
-graph TD
-    subgraph "Step 1: Analysis"
-        A["👤 User posts comment on Issue<br>('@analyst')"] --> B["[agent-analyst.yml]<br>🔍 Analyst Agent"];
-    end
-    subgraph "Step 2: Coding"
-        B -- "Triggers Coder via workflow_dispatch" --> C["[agent-coder.yml]<br>🤖 Coder Agent (Jules)"];
-        C -- "Opens a Pull Request" --> D;
-    end
-    subgraph "Step 3: Review & Self-Correction"
-        D["[agent-reviewer.yml]<br>🔎 Reviewer Agent"] -- "Inspects PR" --> E{"Verdict?"};
-        E -- "✅ Approved" --> F["PR Merged"];
-        E -- "❌ Rejected" --> G["Self-Correction Loop<br>(Reviewer tells Coder to fix it)"];
-        G --> C;
-    end
-```
+- Confirm `JULES_API_KEY` is configured.
+- Confirm PR body/comments contain expected session markers.
+- Check reviewer logs for continuity lookup and API call errors.
 
----
+## FAQ
 
-## 🛠️ Installation
+### Should I use GLM or Gemini?
 
-### Step 1: Clone the Brain
+- Use `glm` for default coding-focused flow.
+- Use `gemini` if your environment/team prefers Gemini behavior and key management.
 
-Copy these folders to your repository:
+### Do I need a GitHub App for this to work?
 
-```bash
-.github/workflows/
-.github/scripts/
-.github/prompts/
-.github/swarm_rules.md
-```
+No. GitHub App setup (`APP_ID`, `APP_PRIVATE_KEY`) is optional for branding/identity improvements.
 
-### Step 2: Add Secrets & Variables
+### Is this only for large repositories?
 
-Go to **Settings > Secrets and variables > Actions** and add:
+No. It works for small repositories too, and becomes more valuable as task/review load increases.
 
-**Secrets:**
+## Roadmap (Short)
 
-- `GLM_API_KEY`: Your z.ai API Key (for GLM-4.7 - recommended)
-- `GEMINI_API_KEY`: Your Google Gemini API Key (alternative)
-- `JULES_API_KEY`: API Key for the Coder Agent trigger.
+- Improve release automation and notes generation
+- Add reliability metrics dashboarding for workflow outcomes
+- Expand documentation for enterprise permission models
+- Improve test strategy split (unit vs e2e vs provider-gated)
 
-**Variables:**
+## Contributing and Security
 
-- `SWARM_MODEL_PROVIDER`: Set to `glm` or `gemini` (default: `glm`)
-
-### Step 3: Define Roles
-
-Edit `.github/swarm_rules.md` to set your project's constitution.
-
----
-
-## 🎨 Bot Customization & Branding
-
-Want your AI to look professional? You can customize the bot's identity.
-
-### Option A: Zero Config (Default)
-
-Uses the standard `github-actions[bot]`.
-
-- **Pros:** No setup required.
-- **Cons:** Generic avatar.
-
-### Option B: Custom Brand (Pro)
-
-Use your own App Name and Logo (e.g., `EnesBot`).
-
-1. Create a [GitHub App](https://github.com/settings/apps/new)
-2. Permissions: `Contents: Read & Write`, `Issues: Read & Write`, `Pull Requests: Read & Write`
-3. Generate **Private Key** and get **App ID**.
-4. Add Secrets: `APP_ID` and `APP_PRIVATE_KEY`.
-
-**Result:** Your bot comments with **your logo** (like the one we generated!) and name.
-
----
-
-## 🤝 Contributing & Support
-
-We love community contributions!
-
-- See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
-- **Rules:** All PRs must pass the AI Reviewer checks.
-- **Contact:** [buzaslan.ea@gmail.com](mailto:buzaslan.ea@gmail.com)
-
----
-
-## 📜 License
-
-MIT - Free to fork, free to use, free to conquer.
+- Contribution guide: [CONTRIBUTING.md](CONTRIBUTING.md)
+- Security policy: [SECURITY.md](SECURITY.md)
+- Project license: [LICENSE](LICENSE)

--- a/README.md
+++ b/README.md
@@ -6,13 +6,25 @@ HiveMind Actions is a serverless multi-agent workflow for repositories that want
 
 ## Quick Links
 
-- Repository: https://github.com/BUZASLAN128/HiveMind-Actions
-- Actions: https://github.com/BUZASLAN128/HiveMind-Actions/actions
-- Releases: https://github.com/BUZASLAN128/HiveMind-Actions/releases
-- Latest Tag: https://github.com/BUZASLAN128/HiveMind-Actions/releases/tag/v2.1.1
-- Analyst Workflow: https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-analyst.yml
-- Coder Workflow: https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-coder.yml
-- Reviewer Workflow: https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-reviewer.yml
+| Destination | Link | External visitor access |
+|---|---|---|
+| Repository | https://github.com/BUZASLAN128/HiveMind-Actions | Code, docs, tags, stars, forks |
+| Actions Hub | https://github.com/BUZASLAN128/HiveMind-Actions/actions | All workflow runs and run history |
+| Releases | https://github.com/BUZASLAN128/HiveMind-Actions/releases | Release notes and downloadable assets |
+| Latest Tag | https://github.com/BUZASLAN128/HiveMind-Actions/releases/tag/v2.1.1 | Snapshot for latest tagged version |
+| Analyst Workflow | https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-analyst.yml | Workflow definition + analyst run list |
+| Coder Workflow | https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-coder.yml | Workflow definition + coder run list |
+| Reviewer Workflow | https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-reviewer.yml | Workflow definition + reviewer run list |
+
+Public visibility note: this repository is public, so outside visitors can open the links above directly.
+
+### Where Analyst / Coder / Reviewer Pages Are Found
+
+1. Open the repository home page.
+2. Click the **Actions** tab.
+3. In the left panel, select **Analyst Workflow**, **Coder Workflow**, or **Reviewer Workflow**.
+
+## Live Workflow Status
 
 [![Analyst Workflow](https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-analyst.yml/badge.svg)](https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-analyst.yml)
 [![Coder Workflow](https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-coder.yml/badge.svg)](https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-coder.yml)

--- a/README.md
+++ b/README.md
@@ -56,19 +56,13 @@ This gives early warnings before risky code reaches production flow.
 
 ## Real PoC from This Repository
 
-### PR PoC (real self-correction and reviews)
+### Verified Self-Correction PoC (PR)
 
 - PR #89 (merged): refactor with real-data test enforcement  
   https://github.com/BUZASLAN128/HiveMind-Actions/pull/89  
-  Evidence: reviewer triggered Jules loop (`Loop: 1/5`) comment in PR.
+  Verified evidence in PR comments: reviewer triggered Jules loop (`Loop: 1/5`) and posted session continuity marker.
 
-- PR #79 (merged): supply-chain hardening by pinning Jules action SHA  
-  https://github.com/BUZASLAN128/HiveMind-Actions/pull/79
-
-- PR #88 (merged): config + metrics integration for swarm agents  
-  https://github.com/BUZASLAN128/HiveMind-Actions/pull/88
-
-### Issue PoC (real push-triggered critical findings)
+### Verified Auto-Review PoC (Push -> Critical Issue)
 
 - Issue #91: Critical issue detected on commit `d6cd5d9`  
   https://github.com/BUZASLAN128/HiveMind-Actions/issues/91
@@ -78,6 +72,14 @@ This gives early warnings before risky code reaches production flow.
 
 - Issue #76: Earlier critical push detection example  
   https://github.com/BUZASLAN128/HiveMind-Actions/issues/76
+
+### Additional Delivery Examples (Not loop evidence)
+
+- PR #79 (merged): supply-chain hardening by pinning Jules action SHA  
+  https://github.com/BUZASLAN128/HiveMind-Actions/pull/79
+
+- PR #88 (merged): config + metrics integration for swarm agents  
+  https://github.com/BUZASLAN128/HiveMind-Actions/pull/88
 
 ## 1-Minute Setup
 

--- a/README.md
+++ b/README.md
@@ -1,214 +1,161 @@
 # HiveMind Actions
 
-Serverless multi-agent automation for GitHub Actions: Analyst plans, Coder implements, Reviewer verifies, and self-correction closes the loop.
+> Turn GitHub into an AI team: **Analyst plans**, **Coder builds**, **Reviewer protects quality**.
+
+HiveMind Actions is a serverless multi-agent workflow for repositories that want faster delivery with automated review and self-correction.
 
 ## Quick Links
 
 - Repository: https://github.com/BUZASLAN128/HiveMind-Actions
 - Actions: https://github.com/BUZASLAN128/HiveMind-Actions/actions
+- Releases: https://github.com/BUZASLAN128/HiveMind-Actions/releases
+- Latest Tag: https://github.com/BUZASLAN128/HiveMind-Actions/releases/tag/v2.1.1
 - Analyst Workflow: https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-analyst.yml
 - Coder Workflow: https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-coder.yml
 - Reviewer Workflow: https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-reviewer.yml
-- Releases: https://github.com/BUZASLAN128/HiveMind-Actions/releases
-- Latest Tag: https://github.com/BUZASLAN128/HiveMind-Actions/releases/tag/v2.1.1
 
 [![Analyst Workflow](https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-analyst.yml/badge.svg)](https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-analyst.yml)
 [![Coder Workflow](https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-coder.yml/badge.svg)](https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-coder.yml)
 [![Reviewer Workflow](https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-reviewer.yml/badge.svg)](https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-reviewer.yml)
 
-## What It Does
+## Why Teams Like It
 
-HiveMind Actions turns a repository into an autonomous collaboration flow:
+- **Productivity:** Analyst-to-Coder handoff is automated.
+- **Quality:** Reviewer checks every PR and blocks bad changes.
+- **Security:** Push-level Beast Mode can create critical issues automatically.
+- **Continuity:** Self-correction loop tries to fix rejected PRs before humans step in.
 
-- Analyst converts issue intent into implementable plans.
-- Coder executes the plan and opens/updates PRs.
-- Reviewer checks code quality, security, and project rules.
-- Reviewer can trigger self-correction when PR quality is insufficient.
-
-## Visual Flow
+## How It Works (Simple)
 
 ```mermaid
 flowchart LR
-    U[User opens issue and comments @analyst] --> A[Analyst]
-    A -->|workflow_dispatch| C[Coder]
+    U[Developer or Maintainer] --> I[Issue + @analyst]
+    I --> A[Analyst Workflow]
+    A --> C[Coder Workflow]
     C --> PR[Pull Request]
-    PR --> R[Reviewer]
-    R -->|Approved| M[Merge Ready]
-    R -->|Rejected| L[Self-Correction Loop]
+    PR --> R[Reviewer Workflow]
+    R -->|Approved| M[Ready to Merge]
+    R -->|Rejected| L[Auto Fix Loop]
     L --> C
-
-    classDef actor fill:#E8F0FE,stroke:#1A73E8,color:#0B1F44;
-    classDef bot fill:#E6F4EA,stroke:#137333,color:#0B3D20;
-    classDef gate fill:#FEF7E0,stroke:#B06000,color:#5A3200;
-    classDef done fill:#F3E8FD,stroke:#9334E6,color:#4A1F75;
-
-    class U actor;
-    class A,C,R bot;
-    class PR,L gate;
-    class M done;
 ```
 
-## Reliability and Retry Model
+## Auto Review on Every Push (Beast Mode)
 
-| Component | Retry Strategy | Max Retry | Backoff | Notes |
-|---|---|---|---|---|
-| Core retry helper (`ai_utils.with_retry`) | Exponential + jitter | 3 (default) | `base_delay=1.0s` | Rate-limit aware (minimum `5s` delay on 429-like errors) |
-| Analyzer model call (`swarm_analyzer.py`) | Uses core helper | 3 | Exponential | Fails hard after all attempts |
-| Reviewer model call (`swarm_reviewer.py`) | Uses core helper | 5 | Exponential | More aggressive retry for review stability |
-| Reviewer self-correction loop (`agent-reviewer.yml`) | Loop guard | 5 | Per-review cycle | Stops loop and asks human intervention after limit |
-| Config baseline (`.github/config.json`) | Shared defaults | 3 | `base_delay=1.0s` | Includes `rate_limit_delay=5.0s` |
-
-## Exit and Failure Semantics
-
-| Layer | Success | Failure Exit/Status | What happens next |
-|---|---|---|---|
-| Python scripts (`swarm_analyzer.py`, `swarm_reviewer.py`) | process exit `0` | `sys.exit(1)` on fatal parse/runtime/config errors | Workflow step fails and error is logged |
-| Workflow jobs | Green check | Red failed step/job | GitHub Actions marks run failed |
-| Self-correction loop | PR converges | Rejected 5 times or missing session/key | Loop stops, issue/PR comment requests manual action |
-
-## Error Recovery Design
+Reviewer also runs on `push` (all branches), not only PRs.
 
 ```mermaid
 flowchart TD
-    S[Review failed] --> K{JULES_API_KEY present?}
-    K -- No --> E1[Post failure comment: missing key]
-    K -- Yes --> Q{Session ID found?}
-    Q -- No --> E2[Post continuity failure<br/>manual trigger required]
-    Q -- Yes --> T[Send feedback to Jules API]
-    T --> O{API call OK?}
-    O -- No --> E3[Post API failure details]
-    O -- Yes --> N[Post loop progress comment]
-    N --> R{Retry count < 5?}
-    R -- Yes --> W[Wait for next PR update and re-review]
-    R -- No --> E4[Stop loop and request human check]
+    P[Push Event] --> RV[Reviewer Scan]
+    RV --> D{Critical issue?}
+    D -- No --> OK[No action needed]
+    D -- Yes --> IS[Open Critical Issue]
+    IS --> HM[Human + AI follow-up]
 ```
 
-## 1-Minute Quickstart
+This gives early warnings before risky code reaches production flow.
 
-1. Copy these paths into your repository:
+## Real PoC from This Repository
+
+### PR PoC (real self-correction and reviews)
+
+- PR #89 (merged): refactor with real-data test enforcement  
+  https://github.com/BUZASLAN128/HiveMind-Actions/pull/89  
+  Evidence: reviewer triggered Jules loop (`Loop: 1/5`) comment in PR.
+
+- PR #79 (merged): supply-chain hardening by pinning Jules action SHA  
+  https://github.com/BUZASLAN128/HiveMind-Actions/pull/79
+
+- PR #88 (merged): config + metrics integration for swarm agents  
+  https://github.com/BUZASLAN128/HiveMind-Actions/pull/88
+
+### Issue PoC (real push-triggered critical findings)
+
+- Issue #91: Critical issue detected on commit `d6cd5d9`  
+  https://github.com/BUZASLAN128/HiveMind-Actions/issues/91
+
+- Issue #92: Critical issue detected on commit `8b39a2c`  
+  https://github.com/BUZASLAN128/HiveMind-Actions/issues/92
+
+- Issue #76: Earlier critical push detection example  
+  https://github.com/BUZASLAN128/HiveMind-Actions/issues/76
+
+## 1-Minute Setup
+
+1. Copy:
    - `.github/workflows/`
    - `.github/scripts/`
    - `.github/prompts/`
    - `.github/swarm_rules.md`
    - `.github/config.json`
-2. Add required secrets and variables in `Settings -> Secrets and variables -> Actions`.
-3. Create an issue and comment `@analyst`.
-4. Analyst runs, dispatches Coder (`workflow_dispatch`), Coder opens PR, Reviewer evaluates PR.
+2. Set secrets/vars in `Settings -> Secrets and variables -> Actions`.
+3. Open issue and comment `@analyst`.
 
-## Configuration Matrix (Source of Truth)
+## Config You Need
 
-### Secrets and Variables
-
-| Name | Required | Used By | Purpose |
-|---|---|---|---|
-| `GLM_API_KEY` | Yes (if provider=`glm`) | `agent-analyst.yml`, `agent-reviewer.yml` | GLM provider access |
-| `GEMINI_API_KEY` | Yes (if provider=`gemini`) | `agent-analyst.yml`, `agent-reviewer.yml` | Gemini provider access |
-| `JULES_API_KEY` | Yes | `agent-coder.yml`, `agent-reviewer.yml` | Coder execution + reviewer self-correction calls |
-| `APP_ID` | Optional | `agent-reviewer.yml` | GitHub App auth for branded bot identity |
-| `APP_PRIVATE_KEY` | Optional | `agent-reviewer.yml` | Pair for `APP_ID` |
-| `SWARM_MODEL_PROVIDER` | Optional (`glm` default) | `agent-analyst.yml`, `agent-reviewer.yml` | Select active model provider |
-
-### Workflow Permission Expectations
-
-| Workflow | Key Permissions |
-|---|---|
-| `agent-analyst.yml` | `actions: write`, issue/comment read-write |
-| `agent-coder.yml` | contents and PR write scopes for automation |
-| `agent-reviewer.yml` | pull request review/comment write scopes |
-
-## Trigger Matrix
-
-| Workflow | Trigger | Notes |
+| Name | Required | Purpose |
 |---|---|---|
-| `agent-analyst.yml` | `issue_comment` (`@analyst` or `@analyze`) | Entry point for tasks |
-| `agent-coder.yml` | `workflow_dispatch` | Dispatched by Analyst; centralized execution |
-| `agent-reviewer.yml` | `pull_request` (`opened`, `synchronize`, `ready_for_review`) | Reviews and may trigger self-correction |
+| `GLM_API_KEY` | Yes (if provider=`glm`) | GLM model access |
+| `GEMINI_API_KEY` | Yes (if provider=`gemini`) | Gemini model access |
+| `JULES_API_KEY` | Yes | Coder runs + reviewer self-correction |
+| `APP_ID` | Optional | GitHub App identity |
+| `APP_PRIVATE_KEY` | Optional | Pair for `APP_ID` |
+| `SWARM_MODEL_PROVIDER` | Optional (`glm` default) | Active provider selector |
+
+## Failure Recovery (Human-Readable)
+
+### Retry and recovery behavior
+
+- Core AI retry helper: **3 attempts** (exponential backoff + jitter).
+- Analyzer AI call: **3 retries**.
+- Reviewer AI call: **5 retries**.
+- Reviewer self-correction loop: **max 5 cycles** (`Loop: n/5`).
+
+### If automation cannot recover
+
+- Missing `JULES_API_KEY` -> reviewer posts failure comment.
+- Missing session continuity -> reviewer posts manual-action comment.
+- Retry limit reached (`5/5`) -> loop stops and human intervention is requested.
+
+### Exit behavior
+
+- Fatal script-level errors exit with `sys.exit(1)`.
+- Failed workflow steps are visible as failed GitHub Action jobs.
 
 ## Version and Release Policy
 
-Current public tags:
+Current tags: `v2.0.0`, `v2.1.0`, `v2.1.1`.
 
-- `v2.0.0`
-- `v2.1.0`
-- `v2.1.1`
+Next prep target: **v2.2.0**.
 
-Preparation target: `v2.2.0`.
+- `MAJOR`: breaking behavior.
+- `MINOR`: new capabilities.
+- `PATCH`: fixes and reliability.
 
-SemVer policy:
+Release prep docs:
 
-- `MAJOR`: breaking workflow/protocol changes.
-- `MINOR`: new capabilities without breaking current setup.
-- `PATCH`: bugfixes and reliability improvements.
+- `CHANGELOG.md`
+- `RELEASE_CHECKLIST.md`
 
-Tag vs Release:
+## Troubleshooting Fast
 
-- **Tag** marks source state (`git tag`).
-- **GitHub Release** is distribution metadata (notes, changelog mapping, assets if added).
-
-For `v2.2.0`, prepare changelog + release notes first, then create a proper GitHub Release from the tag.
-
-## Download and Release Channel
-
-- Releases page: https://github.com/BUZASLAN128/HiveMind-Actions/releases
-- Changelog source: `CHANGELOG.md`
-- Release checklist: `RELEASE_CHECKLIST.md`
-
-Recommended release content:
-
-- Summary of workflow-level changes
-- Breaking/non-breaking classification
-- Security or behavior-impact notes
-- Upgrade guidance from previous tag
-
-## Troubleshooting
-
-### Missing API key errors
-
-- Verify `GLM_API_KEY` or `GEMINI_API_KEY` based on `SWARM_MODEL_PROVIDER`.
-- Verify `JULES_API_KEY` exists for coder/reviewer handoff.
-- If reviewer self-correction is expected, `JULES_API_KEY` is mandatory.
-
-### Analyst does not trigger
-
-- Ensure comment is on an issue and includes `@analyst` or `@analyze`.
-- Ensure commenter has required repository permissions.
-
-### Coder not running after Analyst
-
-- Confirm `agent-analyst.yml` can dispatch workflow (`actions: write`).
-- Check Actions logs for `workflow_dispatch` payload and inputs.
-
-### Reviewer self-correction not firing
-
-- Confirm `JULES_API_KEY` is configured.
-- Confirm PR body/comments contain expected session markers.
-- Check reviewer logs for continuity lookup and API call errors.
-- Check whether retry ceiling is reached (`Max retries (5) reached` log/comment).
+- Analyst not triggering: verify issue comment includes `@analyst` or `@analyze`.
+- Coder not starting: check Analyst run has dispatch permission and valid payload.
+- Reviewer loop not running: verify `JULES_API_KEY` and PR session markers.
+- Too many failures: check if loop reached retry ceiling (`Max retries (5) reached`).
 
 ## FAQ
 
-### Should I use GLM or Gemini?
+### GLM or Gemini?
 
-- Use `glm` for default coding-focused flow.
-- Use `gemini` if your environment/team prefers Gemini behavior and key management.
+- Use `glm` for the default coding-focused route.
+- Use `gemini` if your team already standardizes on Gemini keys/workflows.
 
-### Do I need a GitHub App for this to work?
+### Do I need GitHub App branding?
 
-No. GitHub App setup (`APP_ID`, `APP_PRIVATE_KEY`) is optional for branding/identity improvements.
-
-### Is this only for large repositories?
-
-No. It works for small repositories too, and becomes more valuable as task/review load increases.
-
-## Roadmap (Short)
-
-- Improve release automation and notes generation
-- Add reliability metrics dashboarding for workflow outcomes
-- Expand documentation for enterprise permission models
-- Improve test strategy split (unit vs e2e vs provider-gated)
+No. It works with default bot identity. GitHub App setup is optional.
 
 ## Contributing and Security
 
 - Contribution guide: [CONTRIBUTING.md](CONTRIBUTING.md)
 - Security policy: [SECURITY.md](SECURITY.md)
-- Project license: [LICENSE](LICENSE)
+- License: [LICENSE](LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,97 +1,123 @@
 # HiveMind Actions
 
-> The first serverless AI swarm for GitHub: **Analyst plans**, **Coder builds**, **Reviewer protects quality on PR and push**.
+<p align="center"><b>Serverless AI swarm for GitHub: Analyst plans, Coder builds, Reviewer protects quality on PR and push.</b></p>
+<p align="center">No servers. No always-on bot infra. Just GitHub Actions.</p>
 
-No servers, no bots to host, no custom runtime. Just GitHub Actions and your repo rules.
+<p align="center">
+  <a href="https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-analyst.yml"><img src="https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-analyst.yml/badge.svg" alt="Analyst Workflow"/></a>
+  <a href="https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-coder.yml"><img src="https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-coder.yml/badge.svg" alt="Coder Workflow"/></a>
+  <a href="https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-reviewer.yml"><img src="https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-reviewer.yml/badge.svg" alt="Reviewer Workflow"/></a>
+</p>
 
-[![Analyst Workflow](https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-analyst.yml/badge.svg)](https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-analyst.yml)
-[![Coder Workflow](https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-coder.yml/badge.svg)](https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-coder.yml)
-[![Reviewer Workflow](https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-reviewer.yml/badge.svg)](https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-reviewer.yml)
+<p align="center">
+  <a href="https://github.com/BUZASLAN128/HiveMind-Actions"><img src="https://img.shields.io/github/stars/BUZASLAN128/HiveMind-Actions?style=flat-square" alt="GitHub stars"/></a>
+  <a href="https://github.com/BUZASLAN128/HiveMind-Actions/releases"><img src="https://img.shields.io/github/v/tag/BUZASLAN128/HiveMind-Actions?style=flat-square" alt="Latest tag"/></a>
+  <a href="https://github.com/BUZASLAN128/HiveMind-Actions/pulls"><img src="https://img.shields.io/github/issues-pr/BUZASLAN128/HiveMind-Actions?style=flat-square" alt="Open PRs"/></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/BUZASLAN128/HiveMind-Actions/actions"><b>View Actions</b></a> |
+  <a href="https://github.com/BUZASLAN128/HiveMind-Actions/pull/89"><b>See Self-Correction PoC</b></a> |
+  <a href="https://github.com/BUZASLAN128/HiveMind-Actions/issues/91"><b>See Push Security PoC</b></a> |
+  <a href="https://github.com/BUZASLAN128/HiveMind-Actions/releases"><b>Releases</b></a>
+</p>
+
+## Why This Product
+
+HiveMind turns GitHub events into an autonomous delivery loop:
+
+- Analyst transforms issue intent into execution plan.
+- Coder implements and opens PR.
+- Reviewer enforces standards and blocks risky changes.
+- Reviewer can trigger self-correction to Coder until quality is acceptable.
+
+## What You Get in Practice
+
+| Capability | Why it matters |
+|---|---|
+| Self-correction loop | Reviewer can reject and trigger Coder fixes (`Loop: n/5`) before human rework grows. |
+| Push-level protection | Reviewer also runs on push and can open critical issues early. |
+| Rule-driven output | Agent behavior follows your `.github/swarm_rules.md`. |
+| Serverless runtime | Uses standard GitHub Actions runners only. |
+
+## Live Proof from This Repository
+
+### Verified self-correction
+
+- PR #89 (merged): reviewer loop evidence (`Loop: 1/5`)  
+  https://github.com/BUZASLAN128/HiveMind-Actions/pull/89
+
+### Verified push-level critical detection
+
+- Issue #91: https://github.com/BUZASLAN128/HiveMind-Actions/issues/91
+- Issue #92: https://github.com/BUZASLAN128/HiveMind-Actions/issues/92
+- Issue #76: https://github.com/BUZASLAN128/HiveMind-Actions/issues/76
+
+### Additional delivery examples
+
+- PR #79 (supply-chain hardening): https://github.com/BUZASLAN128/HiveMind-Actions/pull/79
+- PR #88 (config + metrics): https://github.com/BUZASLAN128/HiveMind-Actions/pull/88
 
 ## Quick Access (Public)
 
-| Where | Link |
+This repo is public, so outside visitors can open all links below directly.
+
+| Destination | Link |
 |---|---|
 | Repository | https://github.com/BUZASLAN128/HiveMind-Actions |
-| Actions | https://github.com/BUZASLAN128/HiveMind-Actions/actions |
+| Actions Hub | https://github.com/BUZASLAN128/HiveMind-Actions/actions |
 | Releases | https://github.com/BUZASLAN128/HiveMind-Actions/releases |
 | Latest Tag | https://github.com/BUZASLAN128/HiveMind-Actions/releases/tag/v2.1.1 |
 | Analyst Workflow | https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-analyst.yml |
 | Coder Workflow | https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-coder.yml |
 | Reviewer Workflow | https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-reviewer.yml |
 
-Outside visitors can access these pages directly because this repository is public.
-
-### Where people find Analyst / Coder / Reviewer pages
+### Where outsiders find Analyst / Coder / Reviewer
 
 1. Open repository home page.
 2. Click `Actions`.
 3. Select `Analyst Workflow`, `Coder Workflow`, or `Reviewer Workflow` in the left panel.
 
-## Why This Feels Different
+## 1-Minute Quickstart
 
-- **Autonomous loop:** Reviewer can reject and trigger Coder fix attempts automatically.
-- **Push protection:** Reviewer also runs on push and can open critical issues.
-- **Rule-driven behavior:** Agents follow your `.github/swarm_rules.md`.
-- **No infra overhead:** Everything runs on standard GitHub Actions runners.
-
-## How It Works
-
-```mermaid
-flowchart LR
-    U[Issue Comment: @analyst] --> A[Analyst]
-    A --> C[Coder]
-    C --> PR[Pull Request]
-    PR --> R[Reviewer]
-    R -->|Approved| M[Merge Ready]
-    R -->|Rejected| F[Auto Fix Loop]
-    F --> C
-```
-
-## Auto Review on Every Push
-
-Reviewer workflow listens to both `pull_request` and `push` events.
-
-```mermaid
-flowchart TD
-    P[Push] --> S[Reviewer Scan]
-    S --> D{Critical?}
-    D -- No --> N[No action]
-    D -- Yes --> I[Open Critical Issue]
-```
-
-This means risky changes can be flagged before they reach release flow.
-
-## Proof of Work from This Repo
-
-### Verified self-correction PoC
-
-- PR #89 (merged): reviewer triggered Jules correction loop (`Loop: 1/5`)  
-  https://github.com/BUZASLAN128/HiveMind-Actions/pull/89
-
-### Verified push-level critical detection
-
-- Issue #91 (critical issue from push): https://github.com/BUZASLAN128/HiveMind-Actions/issues/91
-- Issue #92 (critical issue from push): https://github.com/BUZASLAN128/HiveMind-Actions/issues/92
-- Issue #76 (earlier push detection example): https://github.com/BUZASLAN128/HiveMind-Actions/issues/76
-
-### Additional delivery examples
-
-- PR #79 (supply-chain hardening): https://github.com/BUZASLAN128/HiveMind-Actions/pull/79
-- PR #88 (config + metrics integration): https://github.com/BUZASLAN128/HiveMind-Actions/pull/88
-
-## 1-Minute Setup
-
-1. Copy:
+1. Copy these paths into your repository:
    - `.github/workflows/`
    - `.github/scripts/`
    - `.github/prompts/`
    - `.github/swarm_rules.md`
    - `.github/config.json`
-2. Set Actions secrets and variables in `Settings -> Secrets and variables -> Actions`.
+2. Add Actions secrets and variables from `Settings -> Secrets and variables -> Actions`.
 3. Open an issue and comment `@analyst`.
 
-## Config Matrix (Source of Truth)
+## How Swarm Runs
+
+```mermaid
+flowchart LR
+    U[Issue comment: @analyst] --> A[Analyst workflow]
+    A --> C[Coder workflow]
+    C --> PR[Pull Request]
+    PR --> R[Reviewer workflow]
+    R -->|Approved| M[Merge ready]
+    R -->|Rejected| L[Auto fix loop]
+    L --> C
+```
+
+## Auto Review on Every Push
+
+Reviewer runs on both `pull_request` and `push`.
+
+```mermaid
+flowchart TD
+    P[Push event] --> S[Reviewer scan]
+    S --> D{Critical finding?}
+    D -- No --> N[No action]
+    D -- Yes --> I[Open critical issue]
+```
+
+## Operational Details
+
+<details>
+<summary><b>Configuration Matrix (source of truth)</b></summary>
 
 | Name | Required | Used by | Purpose |
 |---|---|---|---|
@@ -102,32 +128,37 @@ This means risky changes can be flagged before they reach release flow.
 | `APP_PRIVATE_KEY` | Optional | Analyst, Reviewer | Pair key for `APP_ID` |
 | `SWARM_MODEL_PROVIDER` | Optional (`glm` default) | All | Provider selector (`glm` or `gemini`) |
 
-## Failure Recovery (Simple)
+</details>
+
+<details>
+<summary><b>Failure recovery and retry policy</b></summary>
 
 - Core AI helper retries: **3 attempts**.
 - Analyst AI retries: **3**.
 - Reviewer AI retries: **5**.
-- Self-correction loop max: **5 cycles** (`Loop: n/5`).
-- Fatal script failures stop with `sys.exit(1)`.
+- Self-correction max loop: **5 cycles** (`Loop: n/5`).
+- Fatal script errors stop with `sys.exit(1)`.
 
-If auto recovery cannot finish:
+If automation cannot recover:
 
 - missing `JULES_API_KEY` -> reviewer posts failure comment,
-- missing session marker -> reviewer asks for manual intervention,
+- missing session marker -> reviewer asks manual intervention,
 - retry ceiling reached -> loop stops and human follow-up is required.
+
+</details>
 
 ## Version and Release Policy
 
 Current tags: `v2.0.0`, `v2.1.0`, `v2.1.1`  
 Next planned minor: `v2.2.0`
 
-SemVer policy:
+SemVer:
 
 - `MAJOR`: breaking changes
 - `MINOR`: new capabilities
 - `PATCH`: bugfix/reliability updates
 
-Release preparation references:
+Release references:
 
 - `CHANGELOG.md`
 - `RELEASE_CHECKLIST.md`
@@ -135,16 +166,16 @@ Release preparation references:
 ## Troubleshooting
 
 - Analyst not triggering: issue comment must include `@analyst` or `@analyze`.
-- Coder not starting: check analyst dispatch step and permissions.
+- Coder not starting: check analyst dispatch permissions and payload.
 - Reviewer loop not running: verify `JULES_API_KEY` and PR session markers.
-- Too many failures: check if max retry (`5`) was reached.
+- Repeated failures: verify if max retry (`5`) was reached.
 
 ## FAQ
 
 ### GLM or Gemini?
 
 - Use `glm` for default coding flow.
-- Use `gemini` if your team already uses Gemini credentials and policies.
+- Use `gemini` if your organization already uses Gemini credentials/policies.
 
 ### Is GitHub App branding required?
 

--- a/README.md
+++ b/README.md
@@ -1,97 +1,84 @@
 # HiveMind Actions
 
-> Turn GitHub into an AI team: **Analyst plans**, **Coder builds**, **Reviewer protects quality**.
+> The first serverless AI swarm for GitHub: **Analyst plans**, **Coder builds**, **Reviewer protects quality on PR and push**.
 
-HiveMind Actions is a serverless multi-agent workflow for repositories that want faster delivery with automated review and self-correction.
-
-## Quick Links
-
-| Destination | Link | External visitor access |
-|---|---|---|
-| Repository | https://github.com/BUZASLAN128/HiveMind-Actions | Code, docs, tags, stars, forks |
-| Actions Hub | https://github.com/BUZASLAN128/HiveMind-Actions/actions | All workflow runs and run history |
-| Releases | https://github.com/BUZASLAN128/HiveMind-Actions/releases | Release notes and downloadable assets |
-| Latest Tag | https://github.com/BUZASLAN128/HiveMind-Actions/releases/tag/v2.1.1 | Snapshot for latest tagged version |
-| Analyst Workflow | https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-analyst.yml | Workflow definition + analyst run list |
-| Coder Workflow | https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-coder.yml | Workflow definition + coder run list |
-| Reviewer Workflow | https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-reviewer.yml | Workflow definition + reviewer run list |
-
-Public visibility note: this repository is public, so outside visitors can open the links above directly.
-
-### Where Analyst / Coder / Reviewer Pages Are Found
-
-1. Open the repository home page.
-2. Click the **Actions** tab.
-3. In the left panel, select **Analyst Workflow**, **Coder Workflow**, or **Reviewer Workflow**.
-
-## Live Workflow Status
+No servers, no bots to host, no custom runtime. Just GitHub Actions and your repo rules.
 
 [![Analyst Workflow](https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-analyst.yml/badge.svg)](https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-analyst.yml)
 [![Coder Workflow](https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-coder.yml/badge.svg)](https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-coder.yml)
 [![Reviewer Workflow](https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-reviewer.yml/badge.svg)](https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-reviewer.yml)
 
-## Why Teams Like It
+## Quick Access (Public)
 
-- **Productivity:** Analyst-to-Coder handoff is automated.
-- **Quality:** Reviewer checks every PR and blocks bad changes.
-- **Security:** Push-level Beast Mode can create critical issues automatically.
-- **Continuity:** Self-correction loop tries to fix rejected PRs before humans step in.
+| Where | Link |
+|---|---|
+| Repository | https://github.com/BUZASLAN128/HiveMind-Actions |
+| Actions | https://github.com/BUZASLAN128/HiveMind-Actions/actions |
+| Releases | https://github.com/BUZASLAN128/HiveMind-Actions/releases |
+| Latest Tag | https://github.com/BUZASLAN128/HiveMind-Actions/releases/tag/v2.1.1 |
+| Analyst Workflow | https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-analyst.yml |
+| Coder Workflow | https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-coder.yml |
+| Reviewer Workflow | https://github.com/BUZASLAN128/HiveMind-Actions/actions/workflows/agent-reviewer.yml |
 
-## How It Works (Simple)
+Outside visitors can access these pages directly because this repository is public.
+
+### Where people find Analyst / Coder / Reviewer pages
+
+1. Open repository home page.
+2. Click `Actions`.
+3. Select `Analyst Workflow`, `Coder Workflow`, or `Reviewer Workflow` in the left panel.
+
+## Why This Feels Different
+
+- **Autonomous loop:** Reviewer can reject and trigger Coder fix attempts automatically.
+- **Push protection:** Reviewer also runs on push and can open critical issues.
+- **Rule-driven behavior:** Agents follow your `.github/swarm_rules.md`.
+- **No infra overhead:** Everything runs on standard GitHub Actions runners.
+
+## How It Works
 
 ```mermaid
 flowchart LR
-    U[Developer or Maintainer] --> I[Issue + @analyst]
-    I --> A[Analyst Workflow]
-    A --> C[Coder Workflow]
+    U[Issue Comment: @analyst] --> A[Analyst]
+    A --> C[Coder]
     C --> PR[Pull Request]
-    PR --> R[Reviewer Workflow]
-    R -->|Approved| M[Ready to Merge]
-    R -->|Rejected| L[Auto Fix Loop]
-    L --> C
+    PR --> R[Reviewer]
+    R -->|Approved| M[Merge Ready]
+    R -->|Rejected| F[Auto Fix Loop]
+    F --> C
 ```
 
-## Auto Review on Every Push (Beast Mode)
+## Auto Review on Every Push
 
-Reviewer also runs on `push` (all branches), not only PRs.
+Reviewer workflow listens to both `pull_request` and `push` events.
 
 ```mermaid
 flowchart TD
-    P[Push Event] --> RV[Reviewer Scan]
-    RV --> D{Critical issue?}
-    D -- No --> OK[No action needed]
-    D -- Yes --> IS[Open Critical Issue]
-    IS --> HM[Human + AI follow-up]
+    P[Push] --> S[Reviewer Scan]
+    S --> D{Critical?}
+    D -- No --> N[No action]
+    D -- Yes --> I[Open Critical Issue]
 ```
 
-This gives early warnings before risky code reaches production flow.
+This means risky changes can be flagged before they reach release flow.
 
-## Real PoC from This Repository
+## Proof of Work from This Repo
 
-### Verified Self-Correction PoC (PR)
+### Verified self-correction PoC
 
-- PR #89 (merged): refactor with real-data test enforcement  
-  https://github.com/BUZASLAN128/HiveMind-Actions/pull/89  
-  Verified evidence in PR comments: reviewer triggered Jules loop (`Loop: 1/5`) and posted session continuity marker.
+- PR #89 (merged): reviewer triggered Jules correction loop (`Loop: 1/5`)  
+  https://github.com/BUZASLAN128/HiveMind-Actions/pull/89
 
-### Verified Auto-Review PoC (Push -> Critical Issue)
+### Verified push-level critical detection
 
-- Issue #91: Critical issue detected on commit `d6cd5d9`  
-  https://github.com/BUZASLAN128/HiveMind-Actions/issues/91
+- Issue #91 (critical issue from push): https://github.com/BUZASLAN128/HiveMind-Actions/issues/91
+- Issue #92 (critical issue from push): https://github.com/BUZASLAN128/HiveMind-Actions/issues/92
+- Issue #76 (earlier push detection example): https://github.com/BUZASLAN128/HiveMind-Actions/issues/76
 
-- Issue #92: Critical issue detected on commit `8b39a2c`  
-  https://github.com/BUZASLAN128/HiveMind-Actions/issues/92
+### Additional delivery examples
 
-- Issue #76: Earlier critical push detection example  
-  https://github.com/BUZASLAN128/HiveMind-Actions/issues/76
-
-### Additional Delivery Examples (Not loop evidence)
-
-- PR #79 (merged): supply-chain hardening by pinning Jules action SHA  
-  https://github.com/BUZASLAN128/HiveMind-Actions/pull/79
-
-- PR #88 (merged): config + metrics integration for swarm agents  
-  https://github.com/BUZASLAN128/HiveMind-Actions/pull/88
+- PR #79 (supply-chain hardening): https://github.com/BUZASLAN128/HiveMind-Actions/pull/79
+- PR #88 (config + metrics integration): https://github.com/BUZASLAN128/HiveMind-Actions/pull/88
 
 ## 1-Minute Setup
 
@@ -101,75 +88,71 @@ This gives early warnings before risky code reaches production flow.
    - `.github/prompts/`
    - `.github/swarm_rules.md`
    - `.github/config.json`
-2. Set secrets/vars in `Settings -> Secrets and variables -> Actions`.
-3. Open issue and comment `@analyst`.
+2. Set Actions secrets and variables in `Settings -> Secrets and variables -> Actions`.
+3. Open an issue and comment `@analyst`.
 
-## Config You Need
+## Config Matrix (Source of Truth)
 
-| Name | Required | Purpose |
-|---|---|---|
-| `GLM_API_KEY` | Yes (if provider=`glm`) | GLM model access |
-| `GEMINI_API_KEY` | Yes (if provider=`gemini`) | Gemini model access |
-| `JULES_API_KEY` | Yes | Coder runs + reviewer self-correction |
-| `APP_ID` | Optional | GitHub App identity |
-| `APP_PRIVATE_KEY` | Optional | Pair for `APP_ID` |
-| `SWARM_MODEL_PROVIDER` | Optional (`glm` default) | Active provider selector |
+| Name | Required | Used by | Purpose |
+|---|---|---|---|
+| `GLM_API_KEY` | Yes if provider=`glm` | Analyst, Reviewer | GLM model API access |
+| `GEMINI_API_KEY` | Yes if provider=`gemini` | Analyst, Reviewer | Gemini model API access |
+| `JULES_API_KEY` | Yes | Coder, Reviewer loop | Code execution + self-correction |
+| `APP_ID` | Optional | Analyst, Reviewer | GitHub App identity |
+| `APP_PRIVATE_KEY` | Optional | Analyst, Reviewer | Pair key for `APP_ID` |
+| `SWARM_MODEL_PROVIDER` | Optional (`glm` default) | All | Provider selector (`glm` or `gemini`) |
 
-## Failure Recovery (Human-Readable)
+## Failure Recovery (Simple)
 
-### Retry and recovery behavior
+- Core AI helper retries: **3 attempts**.
+- Analyst AI retries: **3**.
+- Reviewer AI retries: **5**.
+- Self-correction loop max: **5 cycles** (`Loop: n/5`).
+- Fatal script failures stop with `sys.exit(1)`.
 
-- Core AI retry helper: **3 attempts** (exponential backoff + jitter).
-- Analyzer AI call: **3 retries**.
-- Reviewer AI call: **5 retries**.
-- Reviewer self-correction loop: **max 5 cycles** (`Loop: n/5`).
+If auto recovery cannot finish:
 
-### If automation cannot recover
-
-- Missing `JULES_API_KEY` -> reviewer posts failure comment.
-- Missing session continuity -> reviewer posts manual-action comment.
-- Retry limit reached (`5/5`) -> loop stops and human intervention is requested.
-
-### Exit behavior
-
-- Fatal script-level errors exit with `sys.exit(1)`.
-- Failed workflow steps are visible as failed GitHub Action jobs.
+- missing `JULES_API_KEY` -> reviewer posts failure comment,
+- missing session marker -> reviewer asks for manual intervention,
+- retry ceiling reached -> loop stops and human follow-up is required.
 
 ## Version and Release Policy
 
-Current tags: `v2.0.0`, `v2.1.0`, `v2.1.1`.
+Current tags: `v2.0.0`, `v2.1.0`, `v2.1.1`  
+Next planned minor: `v2.2.0`
 
-Next prep target: **v2.2.0**.
+SemVer policy:
 
-- `MAJOR`: breaking behavior.
-- `MINOR`: new capabilities.
-- `PATCH`: fixes and reliability.
+- `MAJOR`: breaking changes
+- `MINOR`: new capabilities
+- `PATCH`: bugfix/reliability updates
 
-Release prep docs:
+Release preparation references:
 
 - `CHANGELOG.md`
 - `RELEASE_CHECKLIST.md`
 
-## Troubleshooting Fast
+## Troubleshooting
 
-- Analyst not triggering: verify issue comment includes `@analyst` or `@analyze`.
-- Coder not starting: check Analyst run has dispatch permission and valid payload.
+- Analyst not triggering: issue comment must include `@analyst` or `@analyze`.
+- Coder not starting: check analyst dispatch step and permissions.
 - Reviewer loop not running: verify `JULES_API_KEY` and PR session markers.
-- Too many failures: check if loop reached retry ceiling (`Max retries (5) reached`).
+- Too many failures: check if max retry (`5`) was reached.
 
 ## FAQ
 
 ### GLM or Gemini?
 
-- Use `glm` for the default coding-focused route.
-- Use `gemini` if your team already standardizes on Gemini keys/workflows.
+- Use `glm` for default coding flow.
+- Use `gemini` if your team already uses Gemini credentials and policies.
 
-### Do I need GitHub App branding?
+### Is GitHub App branding required?
 
-No. It works with default bot identity. GitHub App setup is optional.
+No. Default bot identity works. `APP_ID` and `APP_PRIVATE_KEY` are optional.
 
 ## Contributing and Security
 
 - Contribution guide: [CONTRIBUTING.md](CONTRIBUTING.md)
 - Security policy: [SECURITY.md](SECURITY.md)
+- Changelog: [CHANGELOG.md](CHANGELOG.md)
 - License: [LICENSE](LICENSE)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,64 @@ HiveMind Actions turns a repository into an autonomous collaboration flow:
 - Reviewer checks code quality, security, and project rules.
 - Reviewer can trigger self-correction when PR quality is insufficient.
 
+## Visual Flow
+
+```mermaid
+flowchart LR
+    U[User opens issue and comments @analyst] --> A[Analyst]
+    A -->|workflow_dispatch| C[Coder]
+    C --> PR[Pull Request]
+    PR --> R[Reviewer]
+    R -->|Approved| M[Merge Ready]
+    R -->|Rejected| L[Self-Correction Loop]
+    L --> C
+
+    classDef actor fill:#E8F0FE,stroke:#1A73E8,color:#0B1F44;
+    classDef bot fill:#E6F4EA,stroke:#137333,color:#0B3D20;
+    classDef gate fill:#FEF7E0,stroke:#B06000,color:#5A3200;
+    classDef done fill:#F3E8FD,stroke:#9334E6,color:#4A1F75;
+
+    class U actor;
+    class A,C,R bot;
+    class PR,L gate;
+    class M done;
+```
+
+## Reliability and Retry Model
+
+| Component | Retry Strategy | Max Retry | Backoff | Notes |
+|---|---|---|---|---|
+| Core retry helper (`ai_utils.with_retry`) | Exponential + jitter | 3 (default) | `base_delay=1.0s` | Rate-limit aware (minimum `5s` delay on 429-like errors) |
+| Analyzer model call (`swarm_analyzer.py`) | Uses core helper | 3 | Exponential | Fails hard after all attempts |
+| Reviewer model call (`swarm_reviewer.py`) | Uses core helper | 5 | Exponential | More aggressive retry for review stability |
+| Reviewer self-correction loop (`agent-reviewer.yml`) | Loop guard | 5 | Per-review cycle | Stops loop and asks human intervention after limit |
+| Config baseline (`.github/config.json`) | Shared defaults | 3 | `base_delay=1.0s` | Includes `rate_limit_delay=5.0s` |
+
+## Exit and Failure Semantics
+
+| Layer | Success | Failure Exit/Status | What happens next |
+|---|---|---|---|
+| Python scripts (`swarm_analyzer.py`, `swarm_reviewer.py`) | process exit `0` | `sys.exit(1)` on fatal parse/runtime/config errors | Workflow step fails and error is logged |
+| Workflow jobs | Green check | Red failed step/job | GitHub Actions marks run failed |
+| Self-correction loop | PR converges | Rejected 5 times or missing session/key | Loop stops, issue/PR comment requests manual action |
+
+## Error Recovery Design
+
+```mermaid
+flowchart TD
+    S[Review failed] --> K{JULES_API_KEY present?}
+    K -- No --> E1[Post failure comment: missing key]
+    K -- Yes --> Q{Session ID found?}
+    Q -- No --> E2[Post continuity failure<br/>manual trigger required]
+    Q -- Yes --> T[Send feedback to Jules API]
+    T --> O{API call OK?}
+    O -- No --> E3[Post API failure details]
+    O -- Yes --> N[Post loop progress comment]
+    N --> R{Retry count < 5?}
+    R -- Yes --> W[Wait for next PR update and re-review]
+    R -- No --> E4[Stop loop and request human check]
+```
+
 ## 1-Minute Quickstart
 
 1. Copy these paths into your repository:
@@ -108,6 +166,7 @@ Recommended release content:
 
 - Verify `GLM_API_KEY` or `GEMINI_API_KEY` based on `SWARM_MODEL_PROVIDER`.
 - Verify `JULES_API_KEY` exists for coder/reviewer handoff.
+- If reviewer self-correction is expected, `JULES_API_KEY` is mandatory.
 
 ### Analyst does not trigger
 
@@ -124,6 +183,7 @@ Recommended release content:
 - Confirm `JULES_API_KEY` is configured.
 - Confirm PR body/comments contain expected session markers.
 - Check reviewer logs for continuity lookup and API call errors.
+- Check whether retry ceiling is reached (`Max retries (5) reached` log/comment).
 
 ## FAQ
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,0 +1,35 @@
+# Release Checklist
+
+Use this checklist before creating a public GitHub Release.
+
+## 1. Scope and Version
+
+- [ ] Confirm release scope (major/minor/patch)
+- [ ] Select SemVer tag (example: `v2.2.0`)
+- [ ] Confirm changelog entries are complete
+
+## 2. Validation
+
+- [ ] Confirm README setup/config sections match workflow implementation
+- [ ] Confirm secrets/variables in docs match `.github/workflows/*.yml`
+- [ ] Confirm workflow links and badges resolve
+- [ ] Run required tests/checks for release branch
+
+## 3. Release Notes
+
+- [ ] Summarize key changes and migration notes
+- [ ] Highlight security-impacting fixes
+- [ ] Include known limitations (if any)
+
+## 4. Git and GitHub
+
+- [ ] Create annotated tag
+- [ ] Push tag to origin
+- [ ] Create GitHub Release from the tag
+- [ ] Attach release notes and reference `CHANGELOG.md`
+
+## 5. Post-Release
+
+- [ ] Verify release page visibility
+- [ ] Share release announcement
+- [ ] Monitor issues for regressions

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,21 +2,39 @@
 
 ## Supported Versions
 
-Use the latest version of HiveMind.
+| Version | Supported |
+| --- | --- |
+| `2.1.x` | Yes |
+| `2.0.x` | Best effort |
+| `< 2.0.0` | No |
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 2.x     | :white_check_mark: |
-| 1.x     | :x:                |
+Policy: latest minor on `main` is the primary supported line.
 
 ## Reporting a Vulnerability
 
-Use this section to tell people how to report a vulnerability.
+Do not use public GitHub issues for vulnerabilities.
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+Report privately via email:
+- **buzaslan.ea@gmail.com**
 
-**Do not report security vulnerabilities through public GitHub issues.**
+Include:
+- affected version/tag
+- impact summary
+- reproduction details
+- possible mitigation (if known)
 
-Please report them via email to **buzaslan.ea@gmail.com**.
+## Response Expectations
+
+- Initial acknowledgement: within 72 hours
+- Triage and severity classification: within 7 days
+- Fix/mitigation target:
+  - Critical: 7-14 days
+  - High: 14-30 days
+  - Medium/Low: next planned release
+
+## Disclosure Process
+
+1. Intake and validation
+2. Severity and scope assessment
+3. Patch development and internal verification
+4. Coordinated disclosure in release notes/changelog


### PR DESCRIPTION
## What changed
- README refresh with quick links, badges, 1-minute quickstart, config matrix, trigger matrix, release/version policy, troubleshooting, FAQ, and roadmap.
- CONTRIBUTING sync with current workflow model (including commit command fix and PR-to-main flow).
- SECURITY policy hardened with concrete reporting/disclosure/SLA expectations.
- Added `CHANGELOG.md` and `RELEASE_CHECKLIST.md` for v2.2.0 release prep.
- Added minimal issue and PR templates for cleaner intake.

## Why
- Improve public project discoverability and trust.
- Reduce onboarding friction for first-time users.
- Make release semantics and prep flow explicit for v2.2.0.

## Changed files
- `README.md`
- `CONTRIBUTING.md`
- `SECURITY.md`
- `CHANGELOG.md`
- `RELEASE_CHECKLIST.md`
- `.github/pull_request_template.md`
- `.github/ISSUE_TEMPLATE/bug_report.yml`
- `.github/ISSUE_TEMPLATE/feature_request.yml`

## Validation evidence
- Secret/variable matrix cross-check with workflow files (`rg`): passed.
- Trigger matrix vs workflow triggers (`issue_comment` / `workflow_dispatch` / `pull_request`): passed.
- Key README link checks (repo/actions/workflows/releases/latest tag): HTTP 200.
- Markdown structure sanity (`README.md` headings + `CHANGELOG.md` sections): passed.

## Release prep checklist (v2.2.0)
- [x] Changelog structure created and historical entries added.
- [x] Release checklist document added.
- [x] README release policy and channel clarified.
- [ ] Create tag `v2.2.0` after merge.
- [ ] Publish GitHub Release notes after tag.